### PR TITLE
Extra settings to manage drop behaviour of killed players

### DIFF
--- a/src/main/java/de/jeff_media/drop2inventory/config/Config.java
+++ b/src/main/java/de/jeff_media/drop2inventory/config/Config.java
@@ -10,6 +10,8 @@ public class Config {
     public static final String COLLECT_BLOCK_EXP = "collect-block-exp";
     public static final String COLLECT_MOB_DROPS = "collect-mob-drops";
     public static final String COLLECT_MOB_EXP = "collect-mob-exp";
+    public static final String COLLECT_PLAYER_DROPS = "collect-player-drops";
+    public static final String COLLECT_PLAYER_EXP = "collect-player-exp";
     public static final String AUTO_CONDENSE_ENABLED_BY_DEFAULT = "auto-condense-enabled-by-default";
     public static final String FORCE_AUTO_CONDENSE = "force-auto-condense";
     public static final String AUTO_SMELT_ENABLED_BY_DEFAULT = "auto-smelt-enabled-by-default";
@@ -77,9 +79,11 @@ public class Config {
         conf.addDefault(SHOW_MESSAGE_AGAIN_AFTER_LOGOUT, true);
         conf.addDefault(COLLECT_BLOCK_DROPS, true);
         conf.addDefault(COLLECT_MOB_DROPS, true);
+        conf.addDefault(COLLECT_PLAYER_DROPS, true);
         conf.addDefault(COLLECT_FISHING_DROPS, false);
         conf.addDefault(COLLECT_BLOCK_EXP, true);
         conf.addDefault(COLLECT_MOB_EXP, true);
+        conf.addDefault(COLLECT_PLAYER_EXP, true);
         conf.addDefault(FORCE_AUTO_CONDENSE,false);
         conf.addDefault(DETECT_LEGACY_DROPS,true);
         conf.addDefault(DEFAULT_BOUNDING_BOX_RADIUS, 2);

--- a/src/main/java/de/jeff_media/drop2inventory/handlers/PermissionChecker.java
+++ b/src/main/java/de/jeff_media/drop2inventory/handlers/PermissionChecker.java
@@ -166,8 +166,13 @@ public class PermissionChecker {
             return false;
         }
 
-        if (!main.getConfig().getBoolean(Config.COLLECT_MOB_DROPS)) {
+        if (!main.getConfig().getBoolean(Config.COLLECT_MOB_DROPS) && !(entity instanceof Player)) {
             if (main.isDebug()) main.debug("Collect mob drops is disabled");
+            return false;
+        }
+
+        if (!main.getConfig().getBoolean(Config.COLLECT_PLAYER_DROPS) && (entity instanceof Player)) {
+            if (main.isDebug()) main.debug("Collect player drops is disabled");
             return false;
         }
 

--- a/src/main/java/de/jeff_media/drop2inventory/listeners/CollectListener.java
+++ b/src/main/java/de/jeff_media/drop2inventory/listeners/CollectListener.java
@@ -150,7 +150,8 @@ public class CollectListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityXP(EntityDeathEvent event) {
-        if(!main.getConfig().getBoolean(Config.COLLECT_MOB_EXP)) return;
+        if(!main.getConfig().getBoolean(Config.COLLECT_MOB_EXP) && !(event.getEntity() instanceof Player)) return;
+        if(!main.getConfig().getBoolean(Config.COLLECT_PLAYER_EXP) && (event.getEntity() instanceof Player)) return;
         LivingEntity dead = event.getEntity();
         Player killer = dead.getKiller();
         if (killer == null) return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,11 +76,17 @@ collect-block-drops: true
 collect-block-exp: true
 
 # when set to true, mob/entity drops will be automatically collected if the plugin is enabled
-# Note: Drops from entities (item frames, minecarts, etc.) count as mob drops
+# Note: Drops from entities (item frames, minecarts, etc.) count as mob drops, however drops from killed players have their own setting
 collect-mob-drops: true
 
 # when set to true, mob/entity experience orbs will be automatically collected if the plugin is enabled
 collect-mob-exp: true
+
+# when set to true, inventory contents of killed players will be automatically collected if the plugin is enabled
+collect-player-drops: true
+
+# when set to true, experience orbs of killed players will be automatically collected if the plugin is enabled
+collect-player-exp: true
 
 # when set to true, fishes / drops caught via fishing will be automatically collected if the plugin is enabled
 # Note: Disabled by default because this also removes the "drop flying towards player" animation


### PR DESCRIPTION
Fairly simple change requested by ero1ne in ticket #3163 to disable drops from killed players, while still having d2i activated for everything else.

(I have never used or contributed to this plugin before and it kinda feels illegal to compile and test it, because I technically don't have a license to use it, so pls review before merging ^-^)